### PR TITLE
Specify supported node.js server port

### DIFF
--- a/ui/src/pages/docs/other/nodejs.md
+++ b/ui/src/pages/docs/other/nodejs.md
@@ -109,6 +109,14 @@ http://nodejs.<projectID>.wedeploy.io
 
 </article>
 
+<article id="4">
+
+## Additional Notes
+
+As of right now, node.js servers running on WeDeploy only accept connections through port 80.
+
+</article>
+
 ## What's next?
 
 * Now you can start building your Node.js based application.


### PR DESCRIPTION
I was trying to set up a socket.io server, and I had it listening on port 3000.  The connection kept timing out on the client side.  It took me a while to figure out that I needed to open port 80 instead :)