### PR TITLE
Remove carthage docs

### DIFF
--- a/ui/src/pages/docs/intro/using-the-api-client.md
+++ b/ui/src/pages/docs/intro/using-the-api-client.md
@@ -63,14 +63,6 @@ Add this to your Podfile:
 pod 'WeDeploy'
 ```
 
-#### Carthage
-
-Add this to your Cartfile:
-
-```swift
-github 'wedeploy/api-swift'
-```
-
 #### API nuances
 
 By default, all swift api requests returns a promise, for example:


### PR DESCRIPTION
The library needs to be open source or have a distribute the binaries in a https cdn to use carthage