### PR TITLE
Reading Progress latches to screen smoothly, mirroring Electricjs.com

### DIFF
--- a/ui/src/layouts/guide.soy
+++ b/ui/src/layouts/guide.soy
@@ -44,7 +44,8 @@
 			<nav class="col-xs-16 col-md-offset-1 col-md-5 col-lg-4">
 				<div class="docs-nav-container">
 					{call AffixedReadingProgress.render}
-						{param elementClasses: 'docs-nav' /}
+						{param elementClasses: 'docs-nav topbar-is-fixed' /}
+						{param offsetTop: 300 /}
 						{param offsetBottom: 200 /}
 					{/call}
 				</div>

--- a/ui/src/styles/_docs.scss
+++ b/ui/src/styles/_docs.scss
@@ -9,6 +9,10 @@
 	@include h4;
 }
 
+.docs-nav.affix.topbar-is-fixed {
+	top: 20px;
+}
+
 .guide-btn-cta .btn span[class*="icon-16-external"] {
 	top: 7px;
 }


### PR DESCRIPTION
Fixes #168 

Fix in Action: https://streamable.com/3gn6e

Overall changes parallel [doc.soy in ElectricJS.](https://github.com/electricjs/electricjs.com/blob/542dabb05ff0b4c788d6a24787d59469732d9426/src/layouts/docs.soy#L46-L47) 

After talking with Jonni, he preferred the feel that ElectricJS.com gives, which is the Reading Progress Menu hugging more of the top of the browser. In actuality, the CSS `top` value in `_docs.scss` for ElectricJS.com was equivalent to WeDeploy.com. However, because of ElectricJS's black menu bar, this impression makes it seem that Progress menu is higher.

Because WeDeploy.com does not have a black menu bar, I had to manually decrease the `top` value to `20px` to give an equivalent impression. Doing also gives a bit more space to cramped Reading Progress menus.

@zenorocha @jonnilundy @ygorcosta please let me know your feedback 👍 


