### PR TITLE
Issue-177 Fixes minor typos on docs/intro pages

### DIFF
--- a/ui/src/pages/docs/intro/environment-variables.md
+++ b/ui/src/pages/docs/intro/environment-variables.md
@@ -30,7 +30,7 @@ WeDeploy can help you to configure environment variables for your services. Each
 **Using the Dashboard**
 
 1) Go to the specific Service page.
-2) Click on Environment Vars.
+2) Click on Environment.
 3) Add your keys and values.
 4) Click on Update Service.
 

--- a/ui/src/pages/docs/intro/using-the-command-line.md
+++ b/ui/src/pages/docs/intro/using-the-command-line.md
@@ -82,7 +82,7 @@ we link --project demo
 
 4. Now your container should be accessible from [http://hosting.demo.wedeploy.me](http://hosting.demo.wedeploy.me)
 
-*On the first first time it might take a few minutes while downloading the hosting image on the background.*
+*The first time you run the project it might take a few minutes while the hosting image is being downloaded in the background.*
 
 </article>
 


### PR DESCRIPTION
While looking through the documentation I noticed a few minor typos.

- The "Environment Variables" tab in the services dashboard is currently named "Environment." The docs steps say to click on "Environment Vars." This fixes the docs to reflect the proper tab name.
- Noticed that the sentence read "On the first first time...". I restructured the sentence a little to be slightly less awkward.
