### PR TITLE
Updates default values for `wedeploy/hosting` environment variables

### DIFF
--- a/node/electric/src/pages/docs/hosting/environment-variables/index.md
+++ b/node/electric/src/pages/docs/hosting/environment-variables/index.md
@@ -26,8 +26,8 @@ Here's a list of all the environment variables you can use with this service.
 
 | Key | Default Value | Description |
 | - | - | - |
-| WEDEPLOY_WEB_PATH | `/` | Path to serve static files |
-| WEDEPLOY_WEB_ERROR_PATH | `/_error` | Path to serve [error pages](/docs/hosting/custom-error-pages/) |
+| WEDEPLOY_WEB_PATH | `./` | Path to serve static files |
+| WEDEPLOY_WEB_ERROR_PATH | `./_error` | Path to serve [error pages](/docs/hosting/custom-error-pages/) |
 
 </div>
 


### PR DESCRIPTION
Hey,

The default values for `wedeploy/hosting`'s WEDEPLOY_WEB_PATH is not an absolute `/`, but a relative `./` (or an absolute /wedeploy-container`). The same applies for `error`.