### PR TITLE
Updates DXP messaging

### DIFF
--- a/node/electric/src/pages/docs/deploy/deploying-liferay-dxp/index.md
+++ b/node/electric/src/pages/docs/deploy/deploying-liferay-dxp/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Deploying Liferay DXP"
+title: "Deploying Liferay DXP Trial"
 description: "Launch a Liferay DXP application in few seconds."
 headerTitle: "Deploy"
 layout: "guide"
@@ -16,7 +16,7 @@ weight: 6
 
 [Liferay DXP](https://www.liferay.com/digital-experience-platform) provides an architecture for companies to digitize business operations, deliver connected customer experiences, and gather actionable customer insight, with the ultimate goal of providing better customer experiences for their clients.
 
-We give you a free 30 day trial period before you must apply a license.
+We give you a free 15 day trial period to test and develop your DXP instance.
 
 </article>
 
@@ -24,7 +24,7 @@ We give you a free 30 day trial period before you must apply a license.
 
 ## Try it yourself
 
-Want to see the process of deploying Liferay DXP step by step?
+Want to see the process of deploying Liferay DXP Trial step by step?
 
 <div class="guide-btn-cta">
 	<a class="btn btn-accent btn-sm" href="/tutorials/liferay-dxp/" target="_blank" data-senna-off>
@@ -135,4 +135,4 @@ Otherwise, Liferay DXP won't calculate the URLs properly under our load balancer
 
 ## What's next?
 
-Now you can start building your Liferay DXP application.
+Now you can start building your Liferay DXP Trial application.

--- a/node/electric/src/pages/docs/deploy/getting-started/index.md
+++ b/node/electric/src/pages/docs/deploy/getting-started/index.md
@@ -162,7 +162,7 @@ We have created a whole array of tutorials to teach you how to start using WeDep
 * **<a data-senna-off target="_blank" href="/tutorials/java/">Java</a>**: Deploy an app using Java and Spring Boot.
 * **<a data-senna-off target="_blank" href="/tutorials/ruby/">Ruby</a>**: Deploy an app using Ruby and Sinatra.
 * **<a data-senna-off target="_blank" href="/tutorials/nodejs/">Node.js</a>**: Deploy an app using Node.js and Express.
-* **<a data-senna-off target="_blank" href="/tutorials/liferay-dxp/">Liferay DXP</a>**: Deploy a Liferay DXP instance.
+* **<a data-senna-off target="_blank" href="/tutorials/liferay-dxp/">Liferay DXP Trial</a>**: Deploy a Liferay DXP instance.
 * **<a data-senna-off target="_blank" href="/tutorials/docker/">Docker</a>**: Deploy a Docker container.
 
 </article>


### PR DESCRIPTION
The goal of this pr is to emphasize that WeDeploy only supports Liferay DXP for testing and development, not production.