### PR TITLE
Fix some README.md issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ To work on the landing page itself;
    npm run build && npm run build:css
    ```
 
-3. Start the local server and watch for file changes(run these in separate
+3. Start the local server and watch for file changes (run these in separate
    tabs):
 
    ```sh
-   npm dev
+   npm run dev
    ```
 
    ```sh


### PR DESCRIPTION
There is a missing space before the parenthesis (`(`) in the documentation, and there is a bad command written (`npm dev` should be `npm run dev`).