### PR TITLE
Remove image version to simplify example

### DIFF
--- a/node/magnet/src/components/PlugNPlay.soy
+++ b/node/magnet/src/components/PlugNPlay.soy
@@ -49,7 +49,7 @@
     <div class="plugnplay-demo-panel -source {$selected == 'source' ? 'is-active' : ''}">
       <pre class="plugnplay-demo-source"><code class="hljs javascript">{lb}{literal}
   "id": "mydata",
-  "image": "wedeploy/data:1.0.0",
+  "image": "wedeploy/data",
   "memory": 512
 {/literal}{rb}</code></pre>
     </div>


### PR DESCRIPTION
I propose we remove the image version from this example on the homepage to provide a simpler view of our services and so that we don't risk showing an outdated version (like it is today).