### PR TITLE
Adds clickout feature to close mobile nav menu - Closes #587

### DIFF
--- a/node/magnet/src/components/Header.js
+++ b/node/magnet/src/components/Header.js
@@ -35,20 +35,35 @@ export default class Header extends Component {
         }
       }
 
-      const $pricingTarget = event.target.closest('[href="#pricing"]');
-
-      if ($pricingTarget) {
+      function collapseNav() {
         const $list = document.querySelector('.nav-list');
         const $toggle = document.querySelector('.nav-toggle');
 
         document.documentElement.setAttribute('data-expanded', false);
-
+        $toggle.setAttribute('aria-expanded', false);
+        $list.setAttribute('aria-expanded', false);
         $toggle.parentNode.setAttribute('aria-expanded', false);
-
         $list.parentNode.setAttribute('aria-expanded', false);
-
         $list.parentNode.removeAttribute('inert');
       }
+
+      const $pricingTarget = event.target.closest('[href="#pricing"]');
+
+      if ($pricingTarget) {
+        collapseNav();
+      }
+
+      const $canvasTarget = event.target.closest('[data-expanded="true"]');
+      const navArea = document.getElementById('nav-list').getBoundingClientRect();
+
+      if ($canvasTarget) {
+        if (navArea.height > 0) {
+          if (event.offsetY > navArea.height) {
+            collapseNav();
+          }
+        }
+      }
+
     });
   }
 }


### PR DESCRIPTION
Now you can tap outside the nav menu on the main page on a mobile device in order to close the menu. Also fixes a bug where clicking the pricing link would not close the nav menu after scrolling to the anchor.

@zenorocha There are some bugs on the component in marble as well - would you like me to add this functionality to that component?

Indirectly related to the connected issue, #587 .