### PR TITLE
Examples used different syntax

### DIFF
--- a/node/electric/src/pages/docs/data/configuring-data/index.md
+++ b/node/electric/src/pages/docs/data/configuring-data/index.md
@@ -98,7 +98,7 @@ You can prevent unauthorized applications and users from accessing certain endpo
   {
     "path": "/movies/*",
     "auth": {
-      "validator": "$auth != null"
+      "validator": "$auth !== null"
     }
   }
 ]
@@ -188,7 +188,7 @@ The validator can be used as an integration with the [Auth service](/docs/auth/)
 {
   "path": "/movies/*",
   "auth": {
-    "validator": "$auth != null"
+    "validator": "$auth !== null"
   }
 }
 ```


### PR DESCRIPTION
I'm not sure which syntax works, I see

https://github.com/wedeploy/wedeploy.com/blob/793d1ef2a298db53ce1be5d9246296af59dba4bb/data/api.json#L26
https://github.com/wedeploy/wedeploy.com/blob/793d1ef2a298db53ce1be5d9246296af59dba4bb/data/api.json#L49

using "!=" though.